### PR TITLE
Update ackermansteer.cpp

### DIFF
--- a/ackermansteer/src/ackermansteer.cpp
+++ b/ackermansteer/src/ackermansteer.cpp
@@ -229,7 +229,7 @@ namespace gazebo {
         switch (i) {
           case FL:
           case FR:
-            steer_ang_curr = steer_joints_[i]->GetAngle(X).Radian();
+            steer_ang_curr = steer_joints_[i]->Position(0);
             steer_error = steer_ang_curr - steer_target_angles_[i];
             steer_cmd_effort = steer_PIDs_[i].Update(steer_error, step_time);
             steer_joints_[i]->SetForce(X, steer_cmd_effort);


### PR DESCRIPTION
if you using gazebo9 or higher so this line needs to updates.
```
***Deprecation:*** math::Angle GetAngle(unsigned int _index) const
***Replacement:*** virtual double Position(const unsigned int _index = 0) const final
```